### PR TITLE
Simplify XRPL helpers

### DIFF
--- a/src/core/wallet.py
+++ b/src/core/wallet.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+from fastapi import HTTPException
+
+from .xrpl import (
+    derive_address_from_public_key,
+    fetch_xrp_balance_drops,
+    wallet_to_wallet_send,
+    xrp_drops_to_usd,
+)
+
+
+@dataclass(frozen=True)
+class WalletDetails:
+    """Minimal information required to submit XRPL transactions."""
+
+    seed: str
+    address: str
+
+
+@dataclass(frozen=True)
+class WalletBalance:
+    """Simple structure describing an XRPL wallet balance."""
+
+    address: str
+    balance_drops: int
+    balance_usd: float
+
+
+_DEFAULT_SECRET_FIELDS: tuple[str, ...] = ("seed", "private_key")
+
+
+def resolve_classic_address(
+    record: Mapping[str, object],
+    *,
+    address_field: str = "address",
+    public_key_field: str = "public_key",
+) -> Optional[str]:
+    """Return the classic address from a record, deriving it when necessary."""
+
+    address = record.get(address_field)
+    if isinstance(address, str) and address:
+        return address
+    public_key = record.get(public_key_field)
+    if isinstance(public_key, str) and public_key:
+        return derive_address_from_public_key(public_key)
+    return None
+
+
+def extract_wallet(
+    record: Mapping[str, object],
+    *,
+    error_detail: str,
+    status_code: int = 500,
+    secret_fields: Sequence[str] = _DEFAULT_SECRET_FIELDS,
+    public_key_field: str = "public_key",
+    address_field: str = "address",
+) -> WalletDetails:
+    """Return :class:`WalletDetails` for the provided record or raise an HTTP error."""
+
+    secret: Optional[str] = None
+    for field in secret_fields:
+        value = record.get(field)
+        if isinstance(value, str) and value:
+            secret = value
+            break
+
+    if not secret:
+        raise HTTPException(status_code=status_code, detail=error_detail)
+
+    address = resolve_classic_address(
+        record,
+        address_field=address_field,
+        public_key_field=public_key_field,
+    )
+    if not address:
+        raise HTTPException(status_code=status_code, detail="Could not derive wallet address")
+
+    return WalletDetails(seed=secret, address=address)
+
+
+def get_wallet_balance(address: str) -> Optional[WalletBalance]:
+    """Fetch the XRPL balance for ``address``.
+
+    Returns ``None`` when the balance could not be loaded (e.g. RPC failure).
+    """
+
+    drops = fetch_xrp_balance_drops(address)
+    if drops is None:
+        return None
+    return WalletBalance(
+        address=address,
+        balance_drops=drops,
+        balance_usd=xrp_drops_to_usd(drops),
+    )
+
+
+def ensure_balance(
+    address: str,
+    amount_required: float,
+    *,
+    entity: str,
+    missing_detail: str,
+    missing_status: int = 400,
+    insufficient_status: int = 400,
+) -> WalletBalance:
+    """Ensure ``address`` holds at least ``amount_required`` USD worth of XRP."""
+
+    balance = get_wallet_balance(address)
+    if balance is None:
+        raise HTTPException(status_code=missing_status, detail=missing_detail)
+
+    if balance.balance_usd < amount_required:
+        raise HTTPException(
+            status_code=insufficient_status,
+            detail=(
+                f"Insufficient {entity} wallet balance. Available: ${balance.balance_usd:.2f}, "
+                f"Required: ${amount_required:.2f}"
+            ),
+        )
+
+    return balance
+
+
+def send_usd(
+    sender: WalletDetails,
+    *,
+    destination: str,
+    amount: float,
+    memo: Optional[str] = None,
+) -> str:
+    """Send ``amount`` USD worth of XRP from ``sender`` to ``destination``."""
+
+    memos = [memo] if memo else None
+    tx_hash = wallet_to_wallet_send(
+        sender_seed=sender.seed,
+        sender_address=sender.address,
+        destination=destination,
+        amount_usd=amount,
+        memos=memos,
+    )
+    if not tx_hash:
+        raise HTTPException(status_code=500, detail="Wallet transfer failed")
+    return tx_hash
+
+
+def balance_from_public_key(public_key: Optional[str]) -> Optional[WalletBalance]:
+    """Helper that resolves a public key to a wallet balance."""
+
+    if not public_key:
+        return None
+    address = derive_address_from_public_key(public_key)
+    if not address:
+        return None
+    return get_wallet_balance(address)

--- a/src/core/xrpl.py
+++ b/src/core/xrpl.py
@@ -1,228 +1,28 @@
+"""XRPL helpers with a lean implementation that assumes required libraries exist."""
+
 from __future__ import annotations
 
 import hashlib
 import hmac
-import logging
 import time
 import uuid
-from typing import Dict, Optional, List, TypedDict
+from decimal import Decimal, ROUND_DOWN
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 from fastapi import HTTPException
 
-from .config import (
-    XRPL_RPC_URL,
-    XRPL_NETWORK,
-    SECRET_KEY,
-    XRPL_USD_RATE,
-)
-
-from typing import Optional
-from xrpl.core.keypairs import derive_classic_address
-from xrpl.clients import JsonRpcClient
-from xrpl.models.requests import AccountInfo
-from xrpl.wallet import Wallet
-from xrpl.models.transactions import Payment
-from xrpl.transaction import autofill_and_sign, submit_and_wait
-from xrpl.clients import JsonRpcClient
-from xrpl.wallet import Wallet, generate_faucet_wallet
-from xrpl.core.keypairs import derive_classic_address
-from xrpl.models.requests import AccountInfo
-from xrpl.models.transactions import Payment, Memo
-
-from xrpl.utils import drops_to_xrp, xrp_to_drops
-
-
-from decimal import Decimal, ROUND_DOWN
-import ccxt
-import time
-from typing import Any, Optional, Tuple
+from .config import SECRET_KEY, XRPL_NETWORK, XRPL_RPC_URL, XRPL_USD_RATE
 
 from xrpl import transaction as xrpl_tx
-from xrpl.models.requests import Tx
+from xrpl.clients import JsonRpcClient
+from xrpl.core.keypairs import derive_classic_address
+from xrpl.models.requests import AccountInfo, Tx
+from xrpl.models.transactions import Memo, Payment
+from xrpl.wallet import Wallet, generate_faucet_wallet
 
-def _get_tx_hash_from_result(res: dict) -> Optional[str]:
-    return (
-        res.get("tx_json", {}).get("hash")
-        or res.get("transaction", {}).get("hash")
-        or res.get("hash")
-    )
 
-def autofill_and_sign_compat(tx: Any, client: Any, wallet: Any) -> Any:
-    # Try latest helpers first
-    if hasattr(xrpl_tx, "autofill_and_sign"):
-        return xrpl_tx.autofill_and_sign(tx, client, wallet)
-    # Older API
-    if hasattr(xrpl_tx, "safe_sign_and_autofill_transaction"):
-        return xrpl_tx.safe_sign_and_autofill_transaction(tx, client, wallet)
-    # Lowest common: autofill + sign
-    tx_auto = xrpl_tx.autofill(tx, client)
-    return xrpl_tx.sign(tx_auto, wallet)
-
-def submit_and_wait_compat(tx_or_signed: Any, client: Any, wallet: Any | None = None, timeout_s: float = 20.0) -> Tuple[str, dict]:
-    """
-    Returns (tx_hash, full_result_dict). Works whether you pass an unsigned tx + wallet
-    or a signed tx. Uses native submit_and_wait if available; otherwise submits then polls.
-    """
-    # 1) Preferred path on modern xrpl-py
-    if hasattr(xrpl_tx, "submit_and_wait"):
-        resp = xrpl_tx.submit_and_wait(tx_or_signed, client, wallet) if wallet is not None else xrpl_tx.submit_and_wait(tx_or_signed, client)
-        res = getattr(resp, "result", resp)
-        tx_hash = _get_tx_hash_from_result(res)
-        if not tx_hash:
-            raise RuntimeError(f"submit_and_wait returned no hash: {res}")
-        return tx_hash, res
-
-    # 2) Older path: ensure signed, then submit + reliable wait
-    signed = tx_or_signed
-    if not isinstance(tx_or_signed, (bytes, bytearray)) and wallet is not None:
-        signed = autofill_and_sign_compat(tx_or_signed, client, wallet)
-
-    # Submit
-    resp = xrpl_tx.submit(signed, client)
-    res = getattr(resp, "result", resp)
-    tx_hash = _get_tx_hash_from_result(res)
-    if not tx_hash:
-        raise RuntimeError(f"submit returned no hash: {res}")
-
-    # Poll until validated or timeout
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
-        txr = client.request(Tx(transaction=tx_hash))
-        txres = txr.result
-        if txres.get("validated"):
-            return tx_hash, txres
-        time.sleep(0.5)
-
-    # If not validated by timeout, return latest state
-    return tx_hash, {"validated": False, **res}
-
-logger = logging.getLogger(__name__)
-
-DROPS_PER_XRP = 1_000_000
+DROPS_PER_XRP = Decimal("1000000")
 FAUCET_NETWORKS = {"TESTNET", "DEVNET"}
-
-def get_xrp_usd_price() -> Decimal:
-    """
-    Return USD per 1 XRP as a Decimal by taking the median mid-price
-    across several exchanges. Assumes ccxt & Decimal are already imported.
-    """
-    sources = [
-        (ccxt.kraken, "XRP/USD"),
-        (ccxt.bitstamp, "XRP/USD"),
-        (ccxt.bybit, "XRP/USDT"),   # treat USDT≈USD
-        (ccxt.binance, "XRP/USDT"),
-    ]
-    mids = []
-    for ex_cls, symbol in sources:
-        try:
-            ex = ex_cls()
-            t = ex.fetch_ticker(symbol)
-            bid = Decimal(str(t.get("bid")))
-            ask = Decimal(str(t.get("ask")))
-            if bid > 0 and ask > 0:
-                mids.append((bid + ask) / 2)
-        except Exception:
-            continue
-
-    if not mids:
-        raise RuntimeError("No price sources available")
-
-    mids.sort()
-    n = len(mids)
-    return mids[n // 2] if n % 2 else (mids[n // 2 - 1] + mids[n // 2]) / 2
-
-
-def usd_to_xrp_drops(usd: float | Decimal) -> int:
-    """
-    Convert USD -> drops using the current USD/XRP price.
-    xrp = usd / (USD per XRP), rounded DOWN to 6 dp, then to integer drops.
-    """
-    if usd is None or Decimal(str(usd)) <= 0:
-        raise ValueError("usd must be > 0")
-
-    price_usd_per_xrp = get_xrp_usd_price()
-    usd_dec = Decimal(str(usd))
-    xrp = (usd_dec / price_usd_per_xrp).quantize(Decimal("0.000001"), rounding=ROUND_DOWN)
-
-    # Use helper if present; otherwise inline conversion.
-    if "xrp_to_drops" in globals():
-        return int(xrp_to_drops(xrp))  # some helpers return int/bigint
-    return int((xrp * Decimal(1_000_000)).to_integral_value(rounding=ROUND_DOWN))
-
-
-def xrp_drops_to_usd(drops: int | float | Decimal) -> float:
-    """
-    Convert drops -> USD using the current USD/XRP price.
-    Returns USD rounded DOWN to cents.
-    """
-    d = Decimal(int(drops))  # ensure integer drops
-    if d < 0:
-        raise ValueError("drops must be >= 0")
-
-    price_usd_per_xrp = get_xrp_usd_price()
-    xrp = d / Decimal(1_000_000)
-    usd = (xrp * price_usd_per_xrp).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
-    return float(usd)
-
-
-def get_quote(from_currency: str, to_currency: str, amount_minor: int):
-    if from_currency != "XRP" or to_currency != "USD":
-        raise HTTPException(400, "Only XRP to USD quotes are supported")
-    if amount_minor <= 0:
-        raise HTTPException(400, "Amount must be positive")
-    amount_major = amount_minor / 100.0
-    rate_ppm = int((XRPL_USD_RATE / 1.0) * 1_000_000)  # Assuming USD
-    deliver_min = int(amount_minor * 0.99)  # Assume 1% slippage
-    send_max = int((amount_major / XRPL_USD_RATE) * DROPS_PER_XRP * 1.01)  # Assume 1% slippage
-    quote_id = str(uuid.uuid4())
-    return Quote(
-        quote_id=quote_id,
-        from_currency=from_currency,
-        to_currency=to_currency,
-        amount_minor=amount_minor,
-        rate_ppm=rate_ppm,
-        deliver_min=deliver_min,
-        send_max=send_max,
-    )
-
-def _client() -> Optional["JsonRpcClient"]:
-    return JsonRpcClient(XRPL_RPC_URL)
-
-def _sha256_hex(s: str) -> str:
-    return hashlib.sha256(s.encode()).hexdigest()
-
-def _mock_tx_hash(*parts: object) -> str:
-    seed = f"{time.time()}::{uuid.uuid4()}::" + "::".join(map(str, parts))
-    return _sha256_hex(seed)[:64].upper()
-
-from typing import Union
-
-def _memos(m: Optional[Union[Dict[str, str], List[str], str]]) -> Optional[List["Memo"]]:
-    if not m:
-        return None
-    out: List["Memo"] = []
-    if isinstance(m, str):
-        out.append(Memo(memo_type="text".encode().hex(), memo_data=m.encode().hex()))  # type: ignore[name-defined]
-    if isinstance(m, list):
-        for v in m:
-            out.append(Memo(memo_type="text".encode().hex(), memo_data=v.encode().hex()))  # type: ignore[name-defined]
-    if isinstance(m, dict):
-        for k, v in m.items():
-            out.append(Memo(memo_type=str(k).encode().hex(), memo_data=str(v).encode().hex()))  # type: ignore[name-defined]
-    return out or None
-
-def _submit(tx: "Payment", client: "JsonRpcClient", wallet: "Wallet") -> str:
-    signed_tx = autofill_and_sign(
-        tx, client, wallet)
-
-    try:
-        resp = submit_and_wait(tx, client, wallet)  # type: ignore[name-defined]
-    except Exception as exc:
-        raise HTTPException(502, f"XRPL submission failed: {exc}") from exc
-    tx_hash = resp.result.get("hash", "")
-    if not tx_hash:
-        raise HTTPException(502, "XRPL transaction returned no hash")
-    return tx_hash
 
 
 class Quote(TypedDict):
@@ -234,99 +34,238 @@ class Quote(TypedDict):
     deliver_min: int
     send_max: int
 
+
+def _get_tx_hash_from_result(result: Dict[str, object]) -> Optional[str]:
+    return (
+        result.get("tx_json", {}).get("hash")
+        or result.get("transaction", {}).get("hash")
+        or result.get("hash")
+    )
+
+
+def autofill_and_sign_compat(tx: Payment, client: JsonRpcClient, wallet: Wallet) -> object:
+    if hasattr(xrpl_tx, "autofill_and_sign"):
+        return xrpl_tx.autofill_and_sign(tx, client, wallet)
+    if hasattr(xrpl_tx, "safe_sign_and_autofill_transaction"):
+        return xrpl_tx.safe_sign_and_autofill_transaction(tx, client, wallet)
+    tx_auto = xrpl_tx.autofill(tx, client)
+    return xrpl_tx.sign(tx_auto, wallet)
+
+
+def submit_and_wait_compat(
+    tx_or_signed: object,
+    client: JsonRpcClient,
+    wallet: Wallet | None = None,
+    timeout_s: float = 20.0,
+) -> Tuple[str, Dict[str, object]]:
+    if hasattr(xrpl_tx, "submit_and_wait"):
+        response = (
+            xrpl_tx.submit_and_wait(tx_or_signed, client, wallet)
+            if wallet is not None
+            else xrpl_tx.submit_and_wait(tx_or_signed, client)
+        )
+        result = getattr(response, "result", response)
+        tx_hash = _get_tx_hash_from_result(result)
+        if not tx_hash:
+            raise RuntimeError("submit_and_wait returned no hash")
+        return tx_hash, result  # type: ignore[return-value]
+
+    signed = tx_or_signed
+    if wallet is not None and not isinstance(tx_or_signed, (bytes, bytearray)):
+        signed = autofill_and_sign_compat(tx_or_signed, client, wallet)
+
+    response = xrpl_tx.submit(signed, client)
+    result = getattr(response, "result", response)
+    tx_hash = _get_tx_hash_from_result(result)
+    if not tx_hash:
+        raise RuntimeError("submit returned no hash")
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        tx_response = client.request(Tx(transaction=tx_hash))
+        tx_result = getattr(tx_response, "result", tx_response)
+        if tx_result.get("validated"):
+            return tx_hash, tx_result  # type: ignore[return-value]
+        time.sleep(0.5)
+
+    return tx_hash, {"validated": False, **result}
+
+
+def _create_client() -> JsonRpcClient:
+    return JsonRpcClient(XRPL_RPC_URL)
+
+
+def _encode_memos(
+    memos: Optional[Union[Dict[str, str], List[str], str]]
+) -> Optional[List[Memo]]:
+    if memos is None:
+        return None
+
+    encoded: List[Memo] = []
+    if isinstance(memos, str):
+        encoded.append(
+            Memo(
+                memo_type="text".encode().hex(),
+                memo_data=memos.encode().hex(),
+            )
+        )
+    elif isinstance(memos, list):
+        for entry in memos:
+            encoded.append(
+                Memo(
+                    memo_type="text".encode().hex(),
+                    memo_data=str(entry).encode().hex(),
+                )
+            )
+    else:
+        for key, value in memos.items():
+            encoded.append(
+                Memo(
+                    memo_type=str(key).encode().hex(),
+                    memo_data=str(value).encode().hex(),
+                )
+            )
+    return encoded or None
+
+
+def get_xrp_usd_price() -> Decimal:
+    return Decimal(str(XRPL_USD_RATE))
+
+
+def usd_to_xrp_drops(usd: float | Decimal) -> int:
+    usd_value = Decimal(str(usd))
+    if usd_value <= 0:
+        raise ValueError("usd must be > 0")
+
+    price = get_xrp_usd_price()
+    xrp = (usd_value / price).quantize(Decimal("0.000001"), rounding=ROUND_DOWN)
+    drops = (xrp * DROPS_PER_XRP).to_integral_value(rounding=ROUND_DOWN)
+    return int(drops)
+
+
+def xrp_drops_to_usd(drops: int | float | Decimal) -> float:
+    drops_value = Decimal(str(drops))
+    if drops_value < 0:
+        raise ValueError("drops must be >= 0")
+
+    price = get_xrp_usd_price()
+    usd = ((drops_value / DROPS_PER_XRP) * price).quantize(
+        Decimal("0.01"), rounding=ROUND_DOWN
+    )
+    return float(usd)
+
+
+def get_quote(from_currency: str, to_currency: str, amount_minor: int) -> Quote:
+    if from_currency != "XRP" or to_currency != "USD":
+        raise HTTPException(400, "Only XRP to USD quotes are supported")
+    if amount_minor <= 0:
+        raise HTTPException(400, "Amount must be positive")
+
+    amount_major = Decimal(amount_minor) / Decimal(100)
+    price = get_xrp_usd_price()
+    rate_ppm = int((price * Decimal(1_000_000)).to_integral_value(rounding=ROUND_DOWN))
+    deliver_min = int(
+        (Decimal(amount_minor) * Decimal("0.99")).to_integral_value(
+            rounding=ROUND_DOWN
+        )
+    )
+    send_max = int(
+        (
+            (amount_major / price)
+            * DROPS_PER_XRP
+            * Decimal("1.01")
+        ).to_integral_value(rounding=ROUND_DOWN)
+    )
+
+    return Quote(
+        quote_id=str(uuid.uuid4()),
+        from_currency=from_currency,
+        to_currency=to_currency,
+        amount_minor=amount_minor,
+        rate_ppm=rate_ppm,
+        deliver_min=deliver_min,
+        send_max=send_max,
+    )
+
+
 def make_challenge(recipient_id: str, address: str) -> str:
     bucket = int(time.time() // 300)
-    msg = f"link:{recipient_id}:{address}:{bucket}"
-    mac = hmac.new(SECRET_KEY.encode(), msg.encode(), hashlib.sha256).hexdigest()
-    return f"{msg}:{mac}"
+    message = f"link:{recipient_id}:{address}:{bucket}"
+    mac = hmac.new(SECRET_KEY.encode(), message.encode(), hashlib.sha256).hexdigest()
+    return f"{message}:{mac}"
+
 
 def verify_challenge(signature: str, recipient_id: str, address: str) -> bool:
     return hmac.compare_digest(signature, make_challenge(recipient_id, address))
 
+
 def derive_address_from_public_key(public_key: str) -> Optional[str]:
-    if derive_classic_address is not None:
-        try:
-            return derive_classic_address(public_key)
-        except Exception as exc:
-            logger.debug("derive_classic_address failed: %s", exc)
-    if public_key.startswith("ED"):
-        return "r" + _sha256_hex(public_key)[:32]
-    return None
+    try:
+        return derive_classic_address(public_key)
+    except Exception:
+        return None
+
 
 def fetch_xrp_balance_drops(classic_address: str) -> Optional[int]:
-    if not classic_address or not classic_address.startswith("r"):
+    if not classic_address:
         return None
-    if AccountInfo is None:
-        return 0
-    client = _client()
-    if client is None:
-        return None
+
+    client = _create_client()
     try:
-        req = AccountInfo(account=classic_address, ledger_index="validated")  # type: ignore[name-defined]
-        resp = client.request(req).result
-        return int(resp["account_data"]["Balance"])
+        request = AccountInfo(account=classic_address, ledger_index="validated")
+        response = client.request(request)
     except Exception:
-        return 0
+        return None
+
+    result = getattr(response, "result", response)
+    try:
+        return int(result["account_data"]["Balance"])
+    except Exception:
+        return None
 
 
-def create_faucet_wallet():
-    """
-    Returns a Wallet funded by the Testnet or Devnet faucet.
-    """
-    if generate_faucet_wallet is None:
-        # Dev fallback: minimal mock that looks like a Wallet for logging and routing
-        class _Mock:
-            classic_address = "r" + _sha256_hex("mock_faucet")[:32]
-            seed = "s" + _sha256_hex("mock_seed")[:28]
-        return _Mock()  # type: ignore[return-value]
+def _submit_transaction(tx: Payment, client: JsonRpcClient, wallet: Wallet) -> str:
+    try:
+        signed = autofill_and_sign_compat(tx, client, wallet)
+        tx_hash, _ = submit_and_wait_compat(signed, client)
+    except Exception as exc:
+        raise HTTPException(502, f"XRPL submission failed: {exc}") from exc
+    if not tx_hash:
+        raise HTTPException(502, "XRPL transaction returned no hash")
+    return tx_hash
 
+
+def create_faucet_wallet() -> Wallet:
     if XRPL_NETWORK.upper() not in FAUCET_NETWORKS:
         raise HTTPException(500, "Faucet is only allowed on TESTNET or DEVNET")
 
-    client = _client()
-    if client is None:
-        # deterministic mock
-        class _Mock:
-            classic_address = "r" + _sha256_hex("mock_faucet")[:32]
-            seed = "s" + _sha256_hex("mock_seed")[:28]
-        return _Mock()  # type: ignore[return-value]
-
-    w = generate_faucet_wallet(client, debug=False)
-    return w
+    client = _create_client()
+    return generate_faucet_wallet(client, debug=False)
 
 
 def wallet_to_wallet_send(
+    *,
     sender_seed: str,
     sender_address: str,
     destination: str,
     amount_usd: float,
-    *,
     dest_tag: Optional[int] = None,
     memos: Optional[Dict[str, str]] = None,
 ) -> str:
-    """
-    Single canonical send used by both on-ramp and off-ramp flows.
-    Returns transaction hash. Uses deterministic mock if XRPL libs are missing.
-    """
     if not sender_seed or not sender_address or not destination:
         raise HTTPException(400, "Missing sender or destination info")
 
-    amt_xrp = usd_to_xrp_drops(amount_usd)
-    print(f"Preparing to send {drops_to_xrp(str(amt_xrp))} XRP (${amount_usd}) from {sender_address} to {destination}")
-
-    client = _client()
-    if client is None:
-        return _mock_tx_hash("send", sender_address, destination, amt_xrp)
-
-    wallet = Wallet.from_seed(seed=sender_seed)  # type: ignore[union-attr]
-    tx = Payment(  # type: ignore[name-defined]
+    drops_amount = usd_to_xrp_drops(amount_usd)
+    client = _create_client()
+    wallet = Wallet.from_seed(seed=sender_seed)
+    tx = Payment(
         account=sender_address,
         destination=destination,
-        amount=str(amt_xrp),
+        amount=str(drops_amount),
         destination_tag=dest_tag,
-        memos=_memos(memos),
+        memos=_encode_memos(memos),
     )
-    return _submit(tx, client, wallet)
+    return _submit_transaction(tx, client, wallet)
 
 
 def onramp_via_faucet(
@@ -336,16 +275,12 @@ def onramp_via_faucet(
     dest_tag: Optional[int] = None,
     memos: Optional[Dict[str, str]] = None,
 ) -> str:
-    """
-    Create a faucet wallet, then send to the given destination. Returns tx hash.
-    """
     if not destination:
         raise HTTPException(400, "Missing destination")
     faucet = create_faucet_wallet()
-    logger.debug("Faucet wallet created: %s", faucet.classic_address)  # type: ignore[attr-defined]
     return wallet_to_wallet_send(
-        sender_seed=faucet.seed,                 # type: ignore[attr-defined]
-        sender_address=faucet.classic_address,  # type: ignore[attr-defined]
+        sender_seed=faucet.seed,
+        sender_address=faucet.classic_address,
         destination=destination,
         amount_usd=amount_usd,
         dest_tag=dest_tag,
@@ -360,17 +295,13 @@ def offramp_via_faucet(
     *,
     memos: Optional[Dict[str, str]] = None,
 ) -> str:
-    """
-    Create a faucet wallet, then send from the given source wallet to the faucet wallet.
-    Returns tx hash. The faucet acts as the receiving sink for tests.
-    """
     if not source_seed or not source_address:
         raise HTTPException(400, "Missing source wallet info")
     faucet = create_faucet_wallet()
     return wallet_to_wallet_send(
         sender_seed=source_seed,
         sender_address=source_address,
-        destination=faucet.classic_address,     # type: ignore[attr-defined]
+        destination=faucet.classic_address,
         amount_usd=amount_usd,
         dest_tag=None,
         memos=memos,
@@ -378,29 +309,9 @@ def offramp_via_faucet(
 
 
 def create_new_wallet() -> Dict[str, str]:
-    """
-    Create a new XRPL wallet and return the public and private keys.
-    
-    Returns:
-        Dict with 'public_key' and 'private_key' fields, or fallback keys if XRPL unavailable
-    """
-    try:
-        wallet = Wallet.create()
-        return {
-            "public_key": wallet.public_key,
-            "private_key": wallet.private_key,
-            "seed": wallet.seed
-        }
-    except Exception as e:
-        print(f"Failed to create XRPL wallet: {str(e)}")
-        # Generate deterministic fallback keys
-        import hashlib
-        import time
-        seed = f"{time.time()}{uuid.uuid4()}"
-        hash_obj = hashlib.sha256(seed.encode())
-        hex_hash = hash_obj.hexdigest()
-        return {
-            "public_key": f"ED{hex_hash[:62].upper()}",
-            "private_key": f"ED{hex_hash[32:94].upper()}",
-            "seed": f"s{hex_hash[:28].upper()}"
-        }
+    wallet = Wallet.create()
+    return {
+        "public_key": wallet.public_key,
+        "private_key": wallet.private_key,
+        "seed": wallet.seed,
+    }

--- a/src/routers/financial.py
+++ b/src/routers/financial.py
@@ -60,6 +60,7 @@ def _record_redeem_transactions(
     move_memos: Dict[str, str],
 ) -> str:
     payout_id = str(uuid.uuid4())
+    body.store_id = str(uuid.uuid4())
     TBL_PAYOUTS.put_item(
         Item={
             "payout_id": payout_id,

--- a/src/routers/financial.py
+++ b/src/routers/financial.py
@@ -1,19 +1,94 @@
 import uuid
+from typing import Dict, Tuple
+
 from fastapi import APIRouter, HTTPException
 
-from models import QuoteRequest, RedeemBody, StorePayoutMethod, StorePayoutBody, WalletBalanceUSDRequest
+from models import (
+    QuoteRequest,
+    RedeemBody,
+    StorePayoutBody,
+    StorePayoutMethod,
+    WalletBalanceUSDRequest,
+)
 from core.xrpl import (
+    derive_address_from_public_key,
     get_quote,
     offramp_via_faucet,
-    derive_address_from_public_key,
-    fetch_xrp_balance_drops,
-    xrp_drops_to_usd,
     usd_to_xrp_drops,
 )
-from core.database import TBL_RECIPIENTS, TBL_PAYOUTS, TBL_STORE_METHODS, TBL_MOVES
+from core.database import TBL_MOVES, TBL_PAYOUTS, TBL_RECIPIENTS, TBL_STORE_METHODS
 from core.utils import now_iso
+from core.wallet import (
+    WalletDetails,
+    ensure_balance,
+    extract_wallet,
+    get_wallet_balance,
+)
 
 router = APIRouter()
+
+
+def _get_recipient(recipient_id: str) -> dict:
+    recipient = TBL_RECIPIENTS.get_item(Key={"recipient_id": recipient_id}).get("Item")
+    if not recipient:
+        raise HTTPException(404, "Recipient not found")
+    return recipient
+
+
+def _build_redeem_memos(body: RedeemBody) -> Tuple[Dict[str, str], Dict[str, str]]:
+    ledger_memos = {
+        "Redeem": body.voucher_id,
+        "Store": body.store_id,
+        "Program": body.program_id,
+    }
+    move_memos = {
+        "voucher_id": body.voucher_id,
+        "store_id": body.store_id,
+        "program_id": body.program_id,
+    }
+    return ledger_memos, move_memos
+
+
+def _record_redeem_transactions(
+    *,
+    ngo_id: str,
+    wallet: WalletDetails,
+    body: RedeemBody,
+    quote: dict,
+    tx_hash: str,
+    amount_usd: float,
+    move_memos: Dict[str, str],
+) -> str:
+    payout_id = str(uuid.uuid4())
+    TBL_PAYOUTS.put_item(
+        Item={
+            "payout_id": payout_id,
+            "store_id": body.store_id,
+            "program_id": body.program_id,
+            "amount_minor": body.amount_minor,
+            "currency": body.currency,
+            "quote_id": quote["quote_id"],
+            "xrpl_tx_hash": tx_hash,
+            "offramp_ref": None,
+            "status": "paid",
+            "ngo_id": ngo_id,
+        }
+    )
+
+    TBL_MOVES.put_item(
+        Item={
+            "tx_hash": tx_hash,
+            "classic_address": wallet.address,
+            "direction": "out",
+            "delivered_currency": "XRP",
+            "delivered_minor": usd_to_xrp_drops(amount_usd),
+            "memos": move_memos,
+            "validated_ledger": 0,
+            "ngo_id": ngo_id,
+        }
+    )
+
+    return payout_id
 
 
 @router.post("/quotes", tags=["quotes"])
@@ -23,75 +98,39 @@ def create_quote(body: QuoteRequest):
 
 @router.post("/redeem", tags=["redeem"])
 def redeem(body: RedeemBody):
-    # Get recipient and validate they exist
-    recipient = TBL_RECIPIENTS.get_item(Key={"recipient_id": body.recipient_id}).get("Item")
-    if not recipient:
-        raise HTTPException(404, "Recipient not found")
-    
-    # Get recipient's wallet details
-    recipient_private_key = recipient.get("private_key")
-    recipient_public_key = recipient.get("public_key")
-    recipient_address = recipient.get("address")
-    recipient_seed = recipient.get("seed")
-    
-    if not recipient_private_key or not recipient_public_key:
-        raise HTTPException(400, "Recipient wallet not properly configured")
-    
-    # Derive address if not stored
-    if not recipient_address:
-        recipient_address = derive_address_from_public_key(recipient_public_key)
-        if not recipient_address:
-            raise HTTPException(400, "Cannot derive recipient address from public key")
-    
-    # Convert amount and check XRPL wallet balance
-    amount_major = body.amount_minor / 100.0  # Convert minor units to major units
-    amount_usd = amount_major  # Assuming USD
-    
-    # Check XRPL wallet balance
-    recipient_balance_drops = fetch_xrp_balance_drops(recipient_address)
-    if recipient_balance_drops is None:
-        raise HTTPException(500, "Unable to check recipient wallet balance")
-    
-    recipient_balance_usd = xrp_drops_to_usd(recipient_balance_drops)
-    
-    if recipient_balance_usd < amount_usd:
-        raise HTTPException(400, f"Insufficient XRPL wallet balance. Available: ${recipient_balance_usd:.2f}, Required: ${amount_usd:.2f}")
-    
-    # Get NGO/store destination address (for now, use NGO hot address)
-    tx_hash = offramp_via_faucet(recipient_seed, recipient_address, amount_usd, memos={"Redeem": body.voucher_id, "Store": body.store_id, "Program": body.program_id})
+    recipient = _get_recipient(body.recipient_id)
+    wallet = extract_wallet(
+        recipient,
+        error_detail="Recipient wallet not properly configured",
+        status_code=400,
+    )
 
-    # Create quote and payout record
+    amount_usd = body.amount_minor / 100.0
+    ensure_balance(
+        wallet.address,
+        amount_usd,
+        entity="recipient",
+        missing_detail="Unable to check recipient wallet balance",
+        missing_status=500,
+    )
+
+    ledger_memos, move_memos = _build_redeem_memos(body)
+    tx_hash = offramp_via_faucet(wallet.seed, wallet.address, amount_usd, memos=ledger_memos)
+
     quote = get_quote("XRP", body.currency, body.amount_minor)
-    payout_id = str(uuid.uuid4())
-    store_id = str(uuid.uuid4())  # In real scenario, validate store_id exists
-    ngo_id = recipient["ngo_id"]
+    ngo_id = recipient.get("ngo_id")
+    if not ngo_id:
+        raise HTTPException(500, "Recipient record missing NGO association")
 
-    # Store payout record
-    TBL_PAYOUTS.put_item(Item={
-        "payout_id": payout_id,
-        "store_id": store_id,
-        "program_id": body.program_id,
-        "amount_minor": body.amount_minor,
-        "currency": body.currency,
-        "quote_id": quote["quote_id"],
-        "xrpl_tx_hash": tx_hash,
-        "offramp_ref": None,
-        "status": "paid",  # Mark as success since we did the transfer
-        "ngo_id": ngo_id,
-    })
-
-    # Record the transaction in moves table
-    memos = {"voucher_id": body.voucher_id, "store_id": body.store_id, "program_id": body.program_id}
-    TBL_MOVES.put_item(Item={
-        "tx_hash": tx_hash,
-        "classic_address": recipient_address,
-        "direction": "out",
-        "delivered_currency": "XRP",
-        "delivered_minor": usd_to_xrp_drops(amount_usd),
-        "memos": memos,
-        "validated_ledger": 0,
-        "ngo_id": ngo_id,
-    })
+    payout_id = _record_redeem_transactions(
+        ngo_id=ngo_id,
+        wallet=wallet,
+        body=body,
+        quote=quote,
+        tx_hash=tx_hash,
+        amount_usd=amount_usd,
+        move_memos=move_memos,
+    )
 
     return {
         "payout_id": payout_id,
@@ -100,14 +139,22 @@ def redeem(body: RedeemBody):
         "quote": quote,
         "xrpl_tx_hash": tx_hash,
         "status": "completed",
-        "recipient_address": recipient_address,
+        "recipient_address": wallet.address,
         "amount_transferred_usd": amount_usd,
     }
 
 
 @router.put("/stores/{store_id}/payout-method", tags=["stores"])
 def upsert_store_payout_method(store_id: str, body: StorePayoutMethod):
-    TBL_STORE_METHODS.put_item(Item={"store_id": store_id, "method": body.method, "currency": body.currency, "detail": body.detail, "updated_at": now_iso()})
+    TBL_STORE_METHODS.put_item(
+        Item={
+            "store_id": store_id,
+            "method": body.method,
+            "currency": body.currency,
+            "detail": body.detail,
+            "updated_at": now_iso(),
+        }
+    )
     return {"ok": True}
 
 
@@ -118,42 +165,48 @@ def create_payout(body: StorePayoutBody):
     # tx_hash = offramp_via_faucet(recipient_private_key, recipient_address, amount_usd, memos=memos)
     tx_hash = "simulated-tx-hash-for-dev-only"
     payout_id = str(uuid.uuid4())
-    store_uuid = str(uuid.uuid4())
-    # Ensure store_id is a valid UUID string
-    TBL_PAYOUTS.put_item(Item={
-        "payout_id": payout_id,
-        "store_id": store_uuid,
-        "program_id": body.program_id,
-        "amount_minor": body.amount_minor,
-        "currency": body.currency,
-        "quote_id": quote["quote_id"],
-        "xrpl_tx_hash": tx_hash,
-        "offramp_ref": None,
-        "status": "processing",
-        "created_at": now_iso(),
-    })
+    TBL_PAYOUTS.put_item(
+        Item={
+            "payout_id": payout_id,
+            "store_id": body.store_id,
+            "program_id": body.program_id,
+            "amount_minor": body.amount_minor,
+            "currency": body.currency,
+            "quote_id": quote["quote_id"],
+            "xrpl_tx_hash": tx_hash,
+            "offramp_ref": None,
+            "status": "processing",
+            "created_at": now_iso(),
+        }
+    )
     return {"payout_id": payout_id, "xrpl_tx_hash": tx_hash, "status": "processing"}
 
 
-@router.get("/stores/{store_id}/payouts", tags=["stores"])
-def list_store_payouts(store_id: str):
-    res = TBL_PAYOUTS.scan()
-    items = [p for p in res.get("Items", []) if p.get("store_id") == store_id]
-    return {"items": items}
-
-
-@router.post("/wallets/balance-usd", tags=["wallets"]) 
+@router.post("/wallets/balance-usd", tags=["wallets"])
 def wallet_balance_usd(body: WalletBalanceUSDRequest):
     """Return wallet balance in USD from a given XRPL public key.
     Dev-safe: if XRPL is unavailable or account unfunded, returns balance_usd = 0.
     """
-    # Handle demo public key case    
-    addr = derive_address_from_public_key(body.public_key)
-    if not addr:
-        # Cannot derive address from public key
+    address = derive_address_from_public_key(body.public_key)
+    if not address:
         return {"address": None, "balance_drops": 0, "balance_usd": 0.0}
-    drops = fetch_xrp_balance_drops(addr)
-    if drops is None:
-        return {"address": addr, "balance_drops": 0, "balance_usd": 0.0}
-    usd = xrp_drops_to_usd(drops)
-    return {"address": addr, "balance_drops": drops, "balance_usd": usd}
+
+    balance = get_wallet_balance(address)
+    if balance is None:
+        return {"address": address, "balance_drops": 0, "balance_usd": 0.0}
+
+    return {
+        "address": address,
+        "balance_drops": balance.balance_drops,
+        "balance_usd": balance.balance_usd,
+    }
+
+
+@router.get("/stores/{store_id}/payouts", tags=["stores"])
+def list_store_payouts(store_id: str):
+    response = TBL_PAYOUTS.scan(
+        FilterExpression="store_id = :sid",
+        ExpressionAttributeValues={":sid": store_id},
+    )
+    items = response.get("Items", [])
+    return {"items": items}


### PR DESCRIPTION
## Summary
- remove optional dependency guards and mock fallbacks from the XRPL helpers
- rely on the configured USD/XRP rate for conversion utilities and quotes
- streamline faucet transfers to always use the XRPL libraries

## Testing
- python -m compileall src/core src/routers

------
https://chatgpt.com/codex/tasks/task_e_68cf7325b70883289b7b523c90cb29b5