### PR TITLE
Add Dockerfile and update Cloud Run deploy pipelines

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -87,13 +87,27 @@ jobs:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
       - uses: google-github-actions/setup-gcloud@v2
 
-      # Deploy from the api subfolder using Buildpacks, no traffic, PR-tagged
+      # Build the Docker image defined in api/Dockerfile
+      - name: Build and push image
+        id: build-image
+        run: |
+          set -euo pipefail
+          PROJECT_ID=$(gcloud config get-value core/project)
+          if [[ -z "$PROJECT_ID" ]]; then
+            echo "Failed to determine GCP project" >&2
+            exit 1
+          fi
+          IMAGE="gcr.io/${PROJECT_ID}/api-backend:${{ github.sha }}"
+          gcloud builds submit api --tag "$IMAGE" --quiet
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      # Deploy the built image tagged for this PR, no traffic by default
       - name: Deploy revision (no traffic)
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: api-backend
           region:  ${{ env.REGION }}
-          source:  api
+          image:   ${{ steps.build-image.outputs.image }}
           flags: "--no-traffic --tag=pr-${{ github.event.number }} --allow-unauthenticated"
 
       # Smoke test the tagged URL

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -83,12 +83,25 @@ jobs:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
       - uses: google-github-actions/setup-gcloud@v2
 
+      - name: Build and push image
+        id: build-image
+        run: |
+          set -euo pipefail
+          PROJECT_ID=$(gcloud config get-value core/project)
+          if [[ -z "$PROJECT_ID" ]]; then
+            echo "Failed to determine GCP project" >&2
+            exit 1
+          fi
+          IMAGE="gcr.io/${PROJECT_ID}/api-backend:${{ github.sha }}"
+          gcloud builds submit api --tag "$IMAGE" --quiet
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
       - name: Deploy revision (no traffic)
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: api-backend
           region:  ${{ env.REGION }}
-          source:  api
+          image:   ${{ steps.build-image.outputs.image }}
           flags: "--no-traffic --tag=staging --allow-unauthenticated"
 
       - name: Smoke test staging

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*.so
+*.env
+.env*
+.git
+.gitignore
+pytest.ini
+README.md
+tests/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install system build/runtime dependencies for scientific stack
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+# Ensure src package is importable
+ENV PYTHONPATH=/app/src \
+    PORT=8080
+
+# Use a non-root user at runtime
+RUN adduser --disabled-password --gecos "" appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8080
+
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- add a production-ready Dockerfile for the FastAPI backend, including OS dependencies and non-root runtime user
- ignore test and local-only artifacts during container builds
- build, push, and deploy the container image in preview and production GitHub Actions workflows

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0d8ae9bac832882e3409700bbf4ac