### PR TITLE
Add environment-aware API base URLs

### DIFF
--- a/NGO-dashboard/components/financial-overview.tsx
+++ b/NGO-dashboard/components/financial-overview.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DollarSign, TrendingUp, TrendingDown, AlertCircle, Loader2 } from "lucide-react"
 import { apiClient } from "@/lib/api"
+import { API_BASE_URL } from "@/lib/config"
 import { DashboardStats } from "@/lib/types"
 import { formatCurrency } from "@/lib/utils"
 
@@ -74,8 +75,7 @@ export function FinancialOverview() {
       }
 
       try {
-        const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
-        const url = new URL("/ws/accounts/dashboard/balance", baseUrl)
+        const url = new URL("/ws/accounts/dashboard/balance", API_BASE_URL)
         url.searchParams.set("token", token)
         url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
 

--- a/NGO-dashboard/lib/api.ts
+++ b/NGO-dashboard/lib/api.ts
@@ -1,6 +1,6 @@
-import { 
-  AuthToken, 
-  LoginRequest, 
+import {
+  AuthToken,
+  LoginRequest,
   RegisterRequest,
   NGO,
   DashboardStats,
@@ -10,8 +10,7 @@ import {
   WalletBalanceUSDResponse,
   BalanceOperationResponse
 } from './types';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { API_BASE_URL } from './config';
 
 class APIClient {
   private token: string | null = null;

--- a/NGO-dashboard/lib/config.ts
+++ b/NGO-dashboard/lib/config.ts
@@ -1,0 +1,56 @@
+const PROD_BACKEND_URL_DEFAULT = "https://relief-919616498022.northamerica-northeast2.run.app"
+const DEFAULT_DEV_URL = "http://127.0.0.1:8000"
+const ALT_DEV_URL = "http://localhost:8000"
+
+function normalizeUrl(url?: string | null): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  const trimmed = url.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  return trimmed.replace(/\/+$/, "")
+}
+
+export function getApiBaseUrl(): string {
+  const explicit = normalizeUrl(process.env.NEXT_PUBLIC_API_URL)
+  if (explicit) {
+    return explicit
+  }
+
+  const env = (
+    process.env.NEXT_PUBLIC_API_ENV ?? process.env.NEXT_PUBLIC_ENVIRONMENT ?? ""
+  ).toLowerCase()
+
+  const prodUrl =
+    [process.env.NEXT_PUBLIC_PROD_API_URL, PROD_BACKEND_URL_DEFAULT]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? PROD_BACKEND_URL_DEFAULT
+
+  const devUrl =
+    [
+      process.env.NEXT_PUBLIC_DEV_API_URL,
+      process.env.NEXT_PUBLIC_LOCAL_API_URL,
+      DEFAULT_DEV_URL,
+      ALT_DEV_URL,
+    ]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? DEFAULT_DEV_URL
+
+  if (env === "prod" || env === "production") {
+    return prodUrl
+  }
+
+  if (env === "dev" || env === "development") {
+    return devUrl
+  }
+
+  if (process.env.NODE_ENV?.toLowerCase() === "production") {
+    return prodUrl
+  }
+
+  return devUrl
+}
+
+export const API_BASE_URL = getApiBaseUrl()

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ XRPL_NETWORK=testnet
 SECRET_KEY=dev-secret
 JWT_SECRET=jwt-secret
 
+### Frontend API selection
+
+Each Next.js dashboard reads a shared configuration to decide whether to call the local development API or the hosted production backend.
+
+- Set `NEXT_PUBLIC_API_ENV=prod` to automatically target `https://relief-919616498022.northamerica-northeast2.run.app`.
+- Leave `NEXT_PUBLIC_API_ENV` unset (or set it to `dev`) to use `http://127.0.0.1:8000` for local FastAPI instances.
+- Override the URLs entirely with `NEXT_PUBLIC_PROD_API_URL`, `NEXT_PUBLIC_DEV_API_URL`, or the higher-priority `NEXT_PUBLIC_API_URL` if you need a custom endpoint.
+
 ## Database Schema
 
 - ngos: NGO organizations

--- a/donor-dashboard/components/impact-dashboard.tsx
+++ b/donor-dashboard/components/impact-dashboard.tsx
@@ -5,7 +5,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { MapPin, Users, DollarSign, Heart, TrendingUp, Clock, CheckCircle, Loader2 } from "lucide-react"
-import { fetchNGOs, transformNGOsToPrograms, calculateImpactData, type NGO } from "@/lib/api"
+import {
+  API_URL,
+  fetchNGOs,
+  transformNGOsToPrograms,
+  calculateImpactData,
+  type NGO,
+} from "@/lib/api"
 
 interface ImpactData {
   totalDonated: number
@@ -115,7 +121,7 @@ export function ImpactDashboard({ impactData: propImpactData }: ImpactDashboardP
     return (
       <div className="text-center p-8">
         <p className="text-red-500 mb-4">{error}</p>
-        <p className="text-muted-foreground">Please check if the API server is running at {process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000"}</p>
+        <p className="text-muted-foreground">Please check if the API server is running at {API_URL}</p>
       </div>
     )
   }

--- a/donor-dashboard/lib/api.ts
+++ b/donor-dashboard/lib/api.ts
@@ -1,5 +1,7 @@
 // lib/api.ts
 
+import { API_BASE_URL } from "./config"
+
 export interface NGO {
   account_id: string
   name: string
@@ -11,7 +13,7 @@ export interface NGO {
   address?: string
 }
 
-export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000"
+export const API_URL = API_BASE_URL
 
 export async function fetchNGOs(): Promise<NGO[]> {
   try {

--- a/donor-dashboard/lib/config.ts
+++ b/donor-dashboard/lib/config.ts
@@ -1,0 +1,56 @@
+const PROD_BACKEND_URL_DEFAULT = "https://relief-919616498022.northamerica-northeast2.run.app"
+const DEFAULT_DEV_URL = "http://127.0.0.1:8000"
+const ALT_DEV_URL = "http://localhost:8000"
+
+function normalizeUrl(url?: string | null): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  const trimmed = url.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  return trimmed.replace(/\/+$/, "")
+}
+
+export function getApiBaseUrl(): string {
+  const explicit = normalizeUrl(process.env.NEXT_PUBLIC_API_URL)
+  if (explicit) {
+    return explicit
+  }
+
+  const env = (
+    process.env.NEXT_PUBLIC_API_ENV ?? process.env.NEXT_PUBLIC_ENVIRONMENT ?? ""
+  ).toLowerCase()
+
+  const prodUrl =
+    [process.env.NEXT_PUBLIC_PROD_API_URL, PROD_BACKEND_URL_DEFAULT]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? PROD_BACKEND_URL_DEFAULT
+
+  const devUrl =
+    [
+      process.env.NEXT_PUBLIC_DEV_API_URL,
+      process.env.NEXT_PUBLIC_LOCAL_API_URL,
+      DEFAULT_DEV_URL,
+      ALT_DEV_URL,
+    ]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? DEFAULT_DEV_URL
+
+  if (env === "prod" || env === "production") {
+    return prodUrl
+  }
+
+  if (env === "dev" || env === "development") {
+    return devUrl
+  }
+
+  if (process.env.NODE_ENV?.toLowerCase() === "production") {
+    return prodUrl
+  }
+
+  return devUrl
+}
+
+export const API_BASE_URL = getApiBaseUrl()

--- a/payment-terminal/components/camera-view.tsx
+++ b/payment-terminal/components/camera-view.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Camera, CameraOff, CheckCircle } from "lucide-react"
+import { API_BASE_URL } from "@/lib/config"
 
 export interface VerificationResult {
   success: boolean
@@ -78,8 +79,7 @@ export function CameraView({ currentStep, onVerificationComplete }: CameraViewPr
     })
 
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
-      const resp = await fetch(`${baseUrl}/face/identify_batch`, {
+      const resp = await fetch(`${API_BASE_URL}/face/identify_batch`, {
         method: "POST",
         body: fd,
       })

--- a/payment-terminal/components/payment-terminal.tsx
+++ b/payment-terminal/components/payment-terminal.tsx
@@ -10,8 +10,7 @@ import { PaymentAccepted } from "@/components/payment-accepted"
 import { CustomerIdleScreen } from "@/components/customer-idle-screen"
 import { WalletDetails } from "@/components/wallet-details"
 import { CreditCard, Shield, Clock } from "lucide-react"
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+import { API_BASE_URL } from "@/lib/config"
 
 export interface CheckoutItem {
   id: string

--- a/payment-terminal/lib/config.ts
+++ b/payment-terminal/lib/config.ts
@@ -1,0 +1,56 @@
+const PROD_BACKEND_URL_DEFAULT = "https://relief-919616498022.northamerica-northeast2.run.app"
+const DEFAULT_DEV_URL = "http://127.0.0.1:8000"
+const ALT_DEV_URL = "http://localhost:8000"
+
+function normalizeUrl(url?: string | null): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  const trimmed = url.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  return trimmed.replace(/\/+$/, "")
+}
+
+export function getApiBaseUrl(): string {
+  const explicit = normalizeUrl(process.env.NEXT_PUBLIC_API_URL)
+  if (explicit) {
+    return explicit
+  }
+
+  const env = (
+    process.env.NEXT_PUBLIC_API_ENV ?? process.env.NEXT_PUBLIC_ENVIRONMENT ?? ""
+  ).toLowerCase()
+
+  const prodUrl =
+    [process.env.NEXT_PUBLIC_PROD_API_URL, PROD_BACKEND_URL_DEFAULT]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? PROD_BACKEND_URL_DEFAULT
+
+  const devUrl =
+    [
+      process.env.NEXT_PUBLIC_DEV_API_URL,
+      process.env.NEXT_PUBLIC_LOCAL_API_URL,
+      DEFAULT_DEV_URL,
+      ALT_DEV_URL,
+    ]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? DEFAULT_DEV_URL
+
+  if (env === "prod" || env === "production") {
+    return prodUrl
+  }
+
+  if (env === "dev" || env === "development") {
+    return devUrl
+  }
+
+  if (process.env.NODE_ENV?.toLowerCase() === "production") {
+    return prodUrl
+  }
+
+  return devUrl
+}
+
+export const API_BASE_URL = getApiBaseUrl()

--- a/user-creation-terminal/components/user-creation-dashboard.tsx
+++ b/user-creation-terminal/components/user-creation-dashboard.tsx
@@ -9,6 +9,7 @@ import { CheckCircle, Camera, User, Shield, FileText } from "lucide-react"
 import { FaceScanStep } from "@/components/face-scan-step"
 import { IdUploadStep } from "@/components/id-upload-step"
 import { ReviewStep } from "@/components/review-step"
+import { API_BASE_URL } from "@/lib/config"
 
 type Step = "welcome" | "face-scan" | "id-upload" | "review" | "complete"
 
@@ -33,7 +34,6 @@ export function UserCreationDashboard() {
   }
 
   const handleFaceScanComplete = async (faceData: any) => {
-    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
     const fd = new FormData()
     if (accountId) fd.append("account_id", accountId)
     for (const f of faceData.files) fd.append("files", f)
@@ -59,7 +59,6 @@ export function UserCreationDashboard() {
   }
 
   const handleReviewComplete = async (updatedData: any) => {
-    const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
     const fd = new FormData()
     if (sessionId) {
       fd.append("session_id", sessionId)

--- a/user-creation-terminal/lib/config.ts
+++ b/user-creation-terminal/lib/config.ts
@@ -1,0 +1,56 @@
+const PROD_BACKEND_URL_DEFAULT = "https://relief-919616498022.northamerica-northeast2.run.app"
+const DEFAULT_DEV_URL = "http://127.0.0.1:8000"
+const ALT_DEV_URL = "http://localhost:8000"
+
+function normalizeUrl(url?: string | null): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  const trimmed = url.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  return trimmed.replace(/\/+$/, "")
+}
+
+export function getApiBaseUrl(): string {
+  const explicit = normalizeUrl(process.env.NEXT_PUBLIC_API_URL)
+  if (explicit) {
+    return explicit
+  }
+
+  const env = (
+    process.env.NEXT_PUBLIC_API_ENV ?? process.env.NEXT_PUBLIC_ENVIRONMENT ?? ""
+  ).toLowerCase()
+
+  const prodUrl =
+    [process.env.NEXT_PUBLIC_PROD_API_URL, PROD_BACKEND_URL_DEFAULT]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? PROD_BACKEND_URL_DEFAULT
+
+  const devUrl =
+    [
+      process.env.NEXT_PUBLIC_DEV_API_URL,
+      process.env.NEXT_PUBLIC_LOCAL_API_URL,
+      DEFAULT_DEV_URL,
+      ALT_DEV_URL,
+    ]
+      .map((candidate) => normalizeUrl(candidate))
+      .find((value): value is string => Boolean(value)) ?? DEFAULT_DEV_URL
+
+  if (env === "prod" || env === "production") {
+    return prodUrl
+  }
+
+  if (env === "dev" || env === "development") {
+    return devUrl
+  }
+
+  if (process.env.NODE_ENV?.toLowerCase() === "production") {
+    return prodUrl
+  }
+
+  return devUrl
+}
+
+export const API_BASE_URL = getApiBaseUrl()


### PR DESCRIPTION
## Summary
- add environment-aware API base URL resolver modules to each Next.js app so the dashboards can switch between development and production backends by environment variable
- update API clients, websocket connections, and UI messaging to use the resolver so production defaults to https://relief-919616498022.northamerica-northeast2.run.app
- document the new frontend environment variables in the main README for easier configuration

## Testing
- npm run lint (donor-dashboard) *(fails: Next.js lint prompts for interactive config)*
- npm run lint (ngo-dashboard) *(fails: missing next/core-web-vitals ESLint config package)*
- npm run lint (payment-terminal) *(fails: missing next/core-web-vitals ESLint config package)*
- npm run lint (user-creation-terminal) *(fails: missing next/core-web-vitals ESLint config package)*

------
https://chatgpt.com/codex/tasks/task_e_68d1879e5910832895bf7c3646933b2d